### PR TITLE
Register locmaf packaging referencing draft-einarsson-moq-locmaf

### DIFF
--- a/draft-ietf-moq-cmsf.md
+++ b/draft-ietf-moq-cmsf.md
@@ -34,6 +34,7 @@ normative:
   MoQTransport: I-D.draft-ietf-moq-transport-18
   MSF:  I-D.draft-ietf-moq-msf-01
   LOC: I-D.draft-ietf-moq-loc-02
+  LOCMAF: I-D.draft-einarsson-moq-locmaf-01
   CMAF:
     author:
       - name: International Organization for Standardization
@@ -89,13 +90,17 @@ MSF and retains all the scope, capabilities and features of MSF including the ca
 format, timeline, ABR switching and LOC support. CMSF is targeted at real-time and
 interactive levels of live latency, as well as VOD content.
 
+CMSF also registers a packaging value for LOCMAF [LOCMAF], a compact encoding of
+CMAF-compliant media that is specified in a separate document and reuses the CMSF
+catalog, timeline, switching, and content-protection machinery unchanged.
+
 This document describes version 1 of the CMSF streaming format.
 
 # MSF Extension
 All of the specifications, requirements, and terminology defined in [MSF] apply to
 implementations of this extension unless explicitly noted otherwise in this document.
 
-# CMAF Packaging
+# CMAF Packaging {#cmafpackaging}
 
 ## Initialization headers {#initheaders}
 A CMAF header is a sequence of CMAF constrained ISO BMFF boxes that do not reference any
@@ -231,6 +236,74 @@ thus presentable.
 ]
 ~~~
 
+
+# LOCMAF Packaging {#locmafpackaging}
+
+LOCMAF [LOCMAF] is a compact packaging of CMAF-compliant media for MOQT. A LOCMAF
+Object carries the same media samples as the equivalent CMAF Chunk, but encodes the
+Movie Fragment Box (moof) header as a set of tagged, delta-coded fields. This lets a
+receiver either reconstruct the original CMAF Chunk for playback via Media Source
+Extensions, or extract the elementary samples directly for playback via WebCodecs.
+The Object encoding, the canonical CMAF reconstruction, and the initialization
+requirements are specified in [LOCMAF]; this document only registers the packaging
+value and its associated catalog field.
+
+Apart from the encoding of the Object payload, a LOCMAF track reuses the CMSF
+machinery defined in this document unchanged. In particular:
+
+* the switching-set, Group, and Object packaging requirements of {{cmafpackaging}}
+  apply to each LOCMAF Object as the CMAF Chunk it reconstructs to;
+* the CMAF header is carried in the catalog exactly as for CMAF tracks, as an
+  initDataList entry referenced from the track by "initRef" (see {{initheaders}});
+  a "cmaf" track and a "locmaf" track wrapping the same source MAY reference the
+  same initDataList entry; and
+* content protection is signaled exactly as for CMAF tracks, via the root-level
+  "contentProtections" array referenced by "contentProtectionRefIDs"
+  (see {{contentprotection}}).
+
+## Catalog description
+
+### LOCMAF packaging type
+This specification extends the allowed packaging values defined in [MSF]
+to include one further entry, as defined in Table 3 below:
+
+| Name              |   Value         |      Reference        |
+|:==================|:================|:======================|
+| LOCMAF            | locmaf          | [LOCMAF]              |
+
+Every Track entry in a CMSF catalog carrying LOCMAF-packaged media data MUST declare
+a "packaging" type value of "locmaf".
+
+### LOCMAF version {#locmafversion}
+Location: T    Required: Conditional   JSON Type: String
+
+A string identifying the LOCMAF packaging version used by the track, expressed as
+"major.minor" (for example, "0.3"). The LOCMAF Object encoding is versioned
+independently of the CMSF catalog "version". This field MUST be present when the
+track "packaging" value is "locmaf" and MUST NOT be present otherwise. A subscriber
+MUST NOT subscribe to a LOCMAF track whose "locmafVersion" it does not support; when
+the catalog offers the same source under an alternative packaging, it MAY select
+that instead.
+
+The following partial catalog illustrates a "locmaf" track that shares its
+initialization data with the equivalent "cmaf" track:
+
+~~~json
+{
+  "name": "hd-locmaf",
+  "renderGroup": 1,
+  "packaging": "locmaf",
+  "locmafVersion": "0.3",
+  "initRef": "init-hd",
+  "role": "video",
+  "codec": "avc1.640028",
+  "width": 1920,
+  "height": 1080,
+  "bitrate": 5000000,
+  "framerate": 30,
+  "altGroup": 1
+}
+~~~
 
 # Content Protection {#contentprotection}
 

--- a/draft-ietf-moq-cmsf.md
+++ b/draft-ietf-moq-cmsf.md
@@ -90,17 +90,18 @@ MSF and retains all the scope, capabilities and features of MSF including the ca
 format, timeline, ABR switching and LOC support. CMSF is targeted at real-time and
 interactive levels of live latency, as well as VOD content.
 
-CMSF also registers a packaging value for LOCMAF [LOCMAF], a compact encoding of
-CMAF-compliant media that is specified in a separate document and reuses the CMSF
-catalog, timeline, switching, and content-protection machinery unchanged.
-
 This document describes version 1 of the CMSF streaming format.
 
 # MSF Extension
 All of the specifications, requirements, and terminology defined in [MSF] apply to
 implementations of this extension unless explicitly noted otherwise in this document.
 
-# CMAF Packaging {#cmafpackaging}
+# Packaging of CMAF-compliant content {#cmafpackaging}
+
+This section specifies how CMAF-compliant content is carried over MOQT and signaled
+in the catalog. The initialization, switching, and Object and Group packaging rules
+defined below apply to both packaging types registered in {{catalogdescription}},
+which differ only in how each Object payload is encoded.
 
 ## Initialization headers {#initheaders}
 A CMAF header is a sequence of CMAF constrained ISO BMFF boxes that do not reference any
@@ -149,26 +150,81 @@ Each MOQT Group
 * The Group boundary MUST align with a CMAF Fragment boundary. CMAF Fragments and CMAF
   Chunks MUST NOT span Groups.
 
-## Catalog description
+## Catalog description {#catalogdescription}
 
-### CMAF packaging type
-This specification extends the allowed packaging values defined in [MSF]
-to include one new entry, as defined in Table 1 below:
+This specification defines two packaging types for CMAF-compliant content, both
+registered as "packaging" values extending those defined in [MSF]: "cmaf"
+({{cmafpackagingtype}}) for native CMAF chunks, and "locmaf" ({{locmafpackaging}})
+for a compact encoding of the same content.
+
+### CMAF packaging type {#cmafpackagingtype}
+The "cmaf" packaging value is registered in {{tab-cmaf-packaging}}:
 
 | Name              |   Value         |      Reference        |
 |:==================|:================|:======================|
 | CMAF              | cmaf            | This RFC              |
+{: #tab-cmaf-packaging title="CMAF packaging value"}
 
 Every Track entry in a CMSF catalog carrying CMAF-packaged media data MUST declare a
 "packaging" type value of "cmaf".
 
+### LOCMAF packaging {#locmafpackaging}
+LOCMAF [LOCMAF] is a compact packaging of CMAF-compliant media for MOQT. A LOCMAF
+Object carries the same media samples as the equivalent CMAF Chunk, but encodes the
+Movie Fragment Box (moof) header as a set of tagged, delta-coded fields. This lets a
+receiver either reconstruct the original CMAF Chunk for playback via Media Source
+Extensions, or extract the elementary samples directly for playback via WebCodecs.
+The Object encoding, the canonical CMAF reconstruction, and the initialization
+requirements are specified in [LOCMAF]; this document only registers the packaging
+value and its associated catalog field.
+
+Apart from the encoding of the Object payload, a LOCMAF track reuses the packaging
+defined in this section unchanged. In particular:
+
+* the switching-set, Group, and Object packaging requirements defined above apply
+  to each LOCMAF Object as the CMAF Chunk it reconstructs to;
+* the CMAF header is carried in the catalog exactly as for CMAF tracks, as an
+  initDataList entry referenced from the track by "initRef" (see {{initheaders}});
+  a "cmaf" track and a "locmaf" track wrapping the same source MAY reference the
+  same initDataList entry; and
+* content protection is signaled exactly as for CMAF tracks, via the root-level
+  "contentProtections" array referenced by "contentProtectionRefIDs"
+  (see {{contentprotection}}).
+
+The "locmaf" packaging value is registered in {{tab-locmaf-packaging}}:
+
+| Name              |   Value         |      Reference        |
+|:==================|:================|:======================|
+| LOCMAF            | locmaf          | [LOCMAF]              |
+{: #tab-locmaf-packaging title="LOCMAF packaging value"}
+
+Every Track entry in a CMSF catalog carrying LOCMAF-packaged media data MUST declare
+a "packaging" type value of "locmaf". Such a track MUST also carry a "locmafVersion"
+field ({{locmafversion}}).
+
+#### LOCMAF version {#locmafversion}
+Location: T    Required: Conditional   JSON Type: String
+
+A string identifying the LOCMAF packaging version used by the track, expressed as
+"major.minor" (for example, "0.3"). The LOCMAF Object encoding is versioned
+independently of the CMSF catalog "version". This field MUST be present when the
+track "packaging" value is "locmaf" and MUST NOT be present otherwise. A subscriber
+MUST NOT subscribe to a LOCMAF track whose "locmafVersion" it does not support; when
+the catalog offers the same source under an alternative packaging, it MAY select
+that instead.
+
+See {{cmaf-locmaf-example}} for a catalog example that offers the same source
+under both "cmaf" and "locmaf" packaging, sharing initialization data.
+
 ### Max SAP starting types
-This specification adds two track-level catalog fields, as defined in Table 2 below:
+This specification adds two track-level catalog fields, as defined in
+{{tab-sap-fields}}:
 
 | Field                       |  Name                  |           Definition      |
 |:============================|:=======================|:==========================|
 | Max Group SAP starting type | maxGrpSapStartingType  | {{maxgrpsapstartingtype}} |
 | Max Object SAP starting type| maxObjSapStartingType  | {{maxobjsapstartingtype}} |
+{: #tab-sap-fields title="CMAF SAP starting-type fields"}
 
 #### Max Group SAP starting type {#maxgrpsapstartingtype}
 Location: T    Required: Optional   JSON Type: Number
@@ -236,74 +292,6 @@ thus presentable.
 ]
 ~~~
 
-
-# LOCMAF Packaging {#locmafpackaging}
-
-LOCMAF [LOCMAF] is a compact packaging of CMAF-compliant media for MOQT. A LOCMAF
-Object carries the same media samples as the equivalent CMAF Chunk, but encodes the
-Movie Fragment Box (moof) header as a set of tagged, delta-coded fields. This lets a
-receiver either reconstruct the original CMAF Chunk for playback via Media Source
-Extensions, or extract the elementary samples directly for playback via WebCodecs.
-The Object encoding, the canonical CMAF reconstruction, and the initialization
-requirements are specified in [LOCMAF]; this document only registers the packaging
-value and its associated catalog field.
-
-Apart from the encoding of the Object payload, a LOCMAF track reuses the CMSF
-machinery defined in this document unchanged. In particular:
-
-* the switching-set, Group, and Object packaging requirements of {{cmafpackaging}}
-  apply to each LOCMAF Object as the CMAF Chunk it reconstructs to;
-* the CMAF header is carried in the catalog exactly as for CMAF tracks, as an
-  initDataList entry referenced from the track by "initRef" (see {{initheaders}});
-  a "cmaf" track and a "locmaf" track wrapping the same source MAY reference the
-  same initDataList entry; and
-* content protection is signaled exactly as for CMAF tracks, via the root-level
-  "contentProtections" array referenced by "contentProtectionRefIDs"
-  (see {{contentprotection}}).
-
-## Catalog description
-
-### LOCMAF packaging type
-This specification extends the allowed packaging values defined in [MSF]
-to include one further entry, as defined in Table 3 below:
-
-| Name              |   Value         |      Reference        |
-|:==================|:================|:======================|
-| LOCMAF            | locmaf          | [LOCMAF]              |
-
-Every Track entry in a CMSF catalog carrying LOCMAF-packaged media data MUST declare
-a "packaging" type value of "locmaf".
-
-### LOCMAF version {#locmafversion}
-Location: T    Required: Conditional   JSON Type: String
-
-A string identifying the LOCMAF packaging version used by the track, expressed as
-"major.minor" (for example, "0.3"). The LOCMAF Object encoding is versioned
-independently of the CMSF catalog "version". This field MUST be present when the
-track "packaging" value is "locmaf" and MUST NOT be present otherwise. A subscriber
-MUST NOT subscribe to a LOCMAF track whose "locmafVersion" it does not support; when
-the catalog offers the same source under an alternative packaging, it MAY select
-that instead.
-
-The following partial catalog illustrates a "locmaf" track that shares its
-initialization data with the equivalent "cmaf" track:
-
-~~~json
-{
-  "name": "hd-locmaf",
-  "renderGroup": 1,
-  "packaging": "locmaf",
-  "locmafVersion": "0.3",
-  "initRef": "init-hd",
-  "role": "video",
-  "codec": "avc1.640028",
-  "width": 1920,
-  "height": 1080,
-  "bitrate": 5000000,
-  "framerate": 30,
-  "altGroup": 1
-}
-~~~
 
 # Content Protection {#contentprotection}
 
@@ -733,6 +721,68 @@ the ECCP model, suitable for testing and development.
       "id": "init-video",
       "type": "inline",
       "data": "AAAAHGZ0eXBjbWYyAAAAAGNtZjJpc282bXA0MQAA..."
+    }
+  ]
+}
+~~~
+
+## CMAF and LOCMAF variants sharing initialization data {#cmaf-locmaf-example}
+
+This example shows a catalog that offers the same English AAC 96kbps audio
+media with both "cmaf" and "locmaf" low-latency packaging for 1s groups.
+They both refer to the same initDataList entry ("init-audio") and declare
+the same language.
+
+When packaging each audio frame as a CMAF chunk, there is a packaging
+overhead of ~40kbps for "cmaf" packaging, but only ~1kbps for "locmaf".
+The "audio-locmaf" track therefore announces a bitrate of 97kbps compared
+to 136kbps for "audio-cmaf". The "locmaf" track additionally carries a
+"locmafVersion" field.
+
+A subscriber selects whichever packaging it supports.
+
+~~~json
+{
+  "version": "1",
+  "generatedAt": 1746104606044,
+  "tracks": [
+    {
+      "name": "audio-cmaf",
+      "renderGroup": 1,
+      "packaging": "cmaf",
+      "isLive": true,
+      "targetLatency": 200,
+      "initRef": "init-audio",
+      "role": "audio",
+      "codec": "mp4a.40.2",
+      "samplerate": 48000,
+      "channelConfig": "2",
+      "lang": "en",
+      "bitrate": 136000,
+      "altGroup": 1
+    },
+    {
+      "name": "audio-locmaf",
+      "renderGroup": 1,
+      "packaging": "locmaf",
+      "locmafVersion": "0.3",
+      "isLive": true,
+      "targetLatency": 200,
+      "initRef": "init-audio",
+      "role": "audio",
+      "codec": "mp4a.40.2",
+      "samplerate": 48000,
+      "channelConfig": "2",
+      "lang": "en",
+      "bitrate": 97000,
+      "altGroup": 1
+    }
+  ],
+  "initDataList": [
+    {
+      "id": "init-audio",
+      "type": "inline",
+      "data": "AAAAHGZ0eXBjbWYyAAAAAGNtZjJpc282bXA0MQ..."
     }
   ]
 }


### PR DESCRIPTION
Per the London interim, LOCMAF should be added as a packaging in CMSF.

Since LOCMAF is not deeply tied to CMSF, @wilaw in moq-wg/msf#24 suggested adding a reference to a standalone draft [draft-einarsson-moq-locmaf-01](https://www.ietf.org/archive/id/draft-einarsson-moq-locmaf-01.html) rather than the full format being folded into CMSF. This also has the advantage that one draft can be updated without the other.

This PR references LOCMAF as a new packaging option in CMSF and defines how it is signaled.

- Adds LOCMAF as a normative reference.
- Adds a short LOCMAF Packaging section registering the locmaf packaging value (Table 3) and a mandatory-when-locmaf `locmafVersion` track field ("major.minor", e.g. "0.3").
- LOCMAF reuses CMSF init (initRef), switching/Group/Object rules, and DRM (contentProtectionRefIDs) unchanged; only the Object-payload encoding differs, and that is specified entirely in [LOCMAF].

Fixes: #24
Fixes: #28